### PR TITLE
Separate email to include |safe_email filter

### DIFF
--- a/templates/modular/about.html.twig
+++ b/templates/modular/about.html.twig
@@ -15,6 +15,9 @@
                         {% for item in page.header.address %}
                         {{ item.line }} <br />
                         {% endfor %}
+                        {% for item in page.header.email %}
+                        {{ item.address|safe_email }} <br />
+                        {% endfor %}
                     </p>
                 </div>
                 {% if page.header.buttons %}


### PR DESCRIPTION
Separating the email address to it's own variable allows for the use of the twig filter "|safe_email" to be used in the template

A pull request of the same subject is made on the ceevee skeleton repository for the proper frontmatter changes to be made