### PR TITLE
Portfolio img items fix #7

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -486,6 +486,7 @@ ul#nav li.current a { color: #F06000; }
 }
 .portfolio-item .item-wrap img {
    vertical-align: bottom;
+   width: 100%;
 }
 .portfolio-item .portfolio-item-meta { padding: 18px }
 .portfolio-item .portfolio-item-meta h5 {


### PR DESCRIPTION
I believe that fix the issue that I opened (#7): the image should occupy all the rectangle. When the dimensions of the image aren't like 250x250, this happens:
![sem titulo](https://cloud.githubusercontent.com/assets/2855921/14069507/3d4436f0-f471-11e5-80fe-dfa5c152be9c.png)
