### PR TITLE
include js in deferred assets block

### DIFF
--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -22,6 +22,7 @@
 
         {% block assets deferred %}
             {{ assets.css()|raw }}
+            {{ assets.js()|raw }}
         {% endblock %}
         {% endblock head%}
     </head>


### PR DESCRIPTION
Without this line, js assets from other Twig templates won't be included on the webpage.
This is an issue for plugins which rely on own javascript libraries, when used with this theme.