### PR TITLE
Update font awesome references

### DIFF
--- a/templates/modular/about.html.twig
+++ b/templates/modular/about.html.twig
@@ -24,7 +24,7 @@
                 <div class="columns download">
                     <p>
                         {% for button in page.header.buttons %}
-                            <a href="{{ button.url }}" class="button"><i class="fa fa-{{ button.icon }}"></i>{{ button.text }}</a>
+                            <a href="{{ button.url }}" class="button"><i class="fa-solid fa-{{ button.icon }}"></i>{{ button.text }}</a>
                         {% endfor %}
                     </p>
                 </div>

--- a/templates/modular/portfolio.html.twig
+++ b/templates/modular/portfolio.html.twig
@@ -27,7 +27,7 @@
             <div class="description-box">
                 <h4>{{ item.title }}</h4>
                 <p>{{ item.content|raw }}.</p>
-                <span class="categories"><i class="fa fa-tag"></i>{{ item.tags }}</span>
+                <span class="categories"><i class="fa-solid fa-tag"></i>{{ item.tags }}</span>
             </div>
             <div class="link-box">
                 <a href="{{ item.details }}">Details</a>

--- a/templates/partials/footer.html.twig
+++ b/templates/partials/footer.html.twig
@@ -3,7 +3,7 @@
         <div class="twelve columns">
             <ul class="social-links">
                 {% for item in site.social %}
-                <li><a href="{{ item.url }}"><i class="fa fa-{{ item.icon }}"></i></a></li>
+                <li><a href="{{ item.url }}"><i class="fa-brands fa-{{ item.icon }}"></i></a></li>
                 {% endfor %}
             </ul>
             <ul class="copyright">

--- a/templates/partials/header.html.twig
+++ b/templates/partials/header.html.twig
@@ -10,7 +10,7 @@
       {% if site.social %}
       <ul class="social">
         {% for item in site.social %}
-        <li><a href="{{ item.url }}"><i class="fa fa-{{ item.icon }}"></i></a></li>
+        <li><a href="{{ item.url }}"><i class="fa-brands fa-{{ item.icon }}"></i></a></li>
         {% endfor %}
       </ul>
       {% endif %}


### PR DESCRIPTION
This branch depends on https://github.com/getgrav/grav-theme-ceevee/pull/21 (Update Font-Awesome to 6.4.0), and relates to https://github.com/getgrav/grav-theme-ceevee/issues/20.

The Font Awesome v4 shim does automatically resolves these issues, however I would lean on that more for end-user content, and not for the base theme.  This is keeping base code in step with a Font Awesome library update.